### PR TITLE
Support and test for python versions up to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest] # [ubuntu-latest, windows-latest, macOS-latest]
-        python_version: ["3.7", "3.8", "3.9"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -35,7 +35,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest] # [ubuntu-latest, windows-latest, macOS-latest]
-        python_version: ["3.7"]
+        python_version: ["3.7", "3.11"]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Evaluation Tool for Anomaly Detection Algorithms on Time Series.
 [![codecov](https://codecov.io/gh/TimeEval/TimeEval/branch/main/graph/badge.svg?token=esrQJQmMQe)](https://codecov.io/gh/TimeEval/TimeEval)
 [![PyPI version](https://badge.fury.io/py/TimeEval.svg)](https://badge.fury.io/py/TimeEval)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![python version 3.7|3.8|3.9](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue)
+![python version 3.7|3.8|3.9|3.10|3.11](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
 [![Downloads](https://pepy.tech/badge/timeeval)](https://pepy.tech/project/timeeval)
 
 </div>
@@ -55,7 +55,7 @@ Builds of `TimeEval` are published to [PyPI](https://pypi.org/project/TimeEval/)
 
 #### Prerequisites
 
-- python >= 3.7, <= 3.9
+- python >= 3.7, <= 3.11
 - pip >= 20
 - Docker (for the anomaly detection algorithms)
 - (optional) `rsync` for distributed TimeEval

--- a/setup.py
+++ b/setup.py
@@ -118,12 +118,14 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9"
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11"
         ],
         packages=find_packages(exclude=("tests", "tests.*")),
         package_data={"timeeval": ["py.typed"], "timeeval_experiments": ["py.typed"]},
         install_requires=load_dependencies(),
-        python_requires=">=3.7, <3.10",
+        python_requires=">=3.7, <=3.11",
         test_suite="tests",
         cmdclass={
             "test": PyTestCommand,

--- a/timeeval/timeeval.py
+++ b/timeeval/timeeval.py
@@ -481,7 +481,7 @@ class TimeEval:
         if short:
             results = results.rename(columns=dict([(k, f"{k}_mean") for k in keys]))
         else:
-            std_results = grouped_results.std(numeric_only=True)[keys]
+            std_results = grouped_results.std()[keys]
             results = results.join(std_results, lsuffix="_mean", rsuffix="_std")
         results["repetitions"] = grouped_results["repetition"].count()
         return results

--- a/timeeval/timeeval.py
+++ b/timeeval/timeeval.py
@@ -196,10 +196,10 @@ class TimeEval:
                    "hyper_params_id"]
     """This list contains all the _fixed_ result data frame's column headers.
     TimeEval dynamically adds the metrics and execution times depending on its configuration.
-    
+
     For metrics, their :func:`~timeeval.utils.metrics.Metric.name` will be used as column header, and TimeEval will add
     the following runtime measurements depending on whether they are applicable to the algorithms in the run or not:
-    
+
     - train_preprocess_time: if :func:`~timeeval.Algorithm.preprocess` is defined
     - train_main_time: if the algorithm is semi-supervised or supervised
     - execute_preprocess_time: if :func:`~timeeval.Algorithm.preprocess` is defined
@@ -209,7 +209,7 @@ class TimeEval:
 
     DEFAULT_RESULT_PATH = Path("./results")
     """Default path for the results.
-    
+
     If you don't specify the ``results_path``, TimeEval will store the evaluation results in the folder ``results``
     within the current working directory.
     """
@@ -481,7 +481,7 @@ class TimeEval:
         if short:
             results = results.rename(columns=dict([(k, f"{k}_mean") for k in keys]))
         else:
-            std_results = grouped_results.std()[keys]
+            std_results = grouped_results.std(numeric_only=True)[keys]
             results = results.join(std_results, lsuffix="_mean", rsuffix="_std")
         results["repetitions"] = grouped_results["repetition"].count()
         return results


### PR DESCRIPTION
With python==3.12, pandas<2.0.0 does not exist. Thus, we do not support it currently. At some point, we should drop python==3.7 support and upgrade the versions of our dependencies.