### PR TITLE
Allow TimeEval runs without computing metrics

### DIFF
--- a/tests/test_timeeval_exceptions.py
+++ b/tests/test_timeeval_exceptions.py
@@ -8,7 +8,15 @@ import numpy as np
 import pandas as pd
 
 from tests.fixtures.algorithms import ErroneousAlgorithm
-from timeeval import TimeEval, Algorithm, Datasets, DatasetManager, Status, ResourceConstraints, TrainingType
+from timeeval import (
+    TimeEval,
+    Algorithm,
+    Datasets,
+    DatasetManager,
+    Status,
+    ResourceConstraints,
+    TrainingType,
+)
 from timeeval.adapters import FunctionAdapter
 from timeeval.metrics import DefaultMetrics
 
@@ -16,17 +24,29 @@ from timeeval.metrics import DefaultMetrics
 class TestTimeEvalExceptions(unittest.TestCase):
     def setUp(self) -> None:
         self.datasets_config = Path("./tests/example_data/datasets.json")
-        self.datasets: Datasets = DatasetManager("./tests/example_data", custom_datasets_file=self.datasets_config)
-        self.identity_algorithm = Algorithm(name="test", main=FunctionAdapter.identity(), data_as_file=False)
+        self.datasets: Datasets = DatasetManager(
+            "./tests/example_data", custom_datasets_file=self.datasets_config
+        )
+        self.identity_algorithm = Algorithm(
+            name="test", main=FunctionAdapter.identity(), data_as_file=False
+        )
 
     @patch("timeeval._core.experiments.load_dataset")
     def test_wrong_df_shape(self, mock_load):
         df = pd.DataFrame(np.random.rand(10, 2))
         mock_load.side_effect = [df]
         with tempfile.TemporaryDirectory() as tmp_path:
-            timeeval = TimeEval(self.datasets, [("custom", "dataset.1")], [self.identity_algorithm], results_path=Path(tmp_path))
+            timeeval = TimeEval(
+                self.datasets,
+                [("custom", "dataset.1")],
+                [self.identity_algorithm],
+                results_path=Path(tmp_path),
+            )
             timeeval.run()
-        self.assertTrue("has a shape that was not expected" in timeeval.results.iloc[0].error_message)
+        self.assertTrue(
+            "has a shape that was not expected"
+            in timeeval.results.iloc[0].error_message
+        )
 
     def test_no_datasets(self):
         with self.assertRaises(AssertionError) as ex:
@@ -40,49 +60,82 @@ class TestTimeEvalExceptions(unittest.TestCase):
 
     def test_wrong_repetition_no(self):
         with self.assertRaises(AssertionError) as ex:
-            TimeEval(self.datasets, [("custom", "dataset.1")], [self.identity_algorithm],
-                     repetitions=0)
+            TimeEval(
+                self.datasets,
+                [("custom", "dataset.1")],
+                [self.identity_algorithm],
+                repetitions=0,
+            )
         self.assertIn("repetitions are not supported", str(ex.exception))
 
     def test_wrong_n_jobs(self):
         with self.assertRaises(AssertionError) as ex:
-            TimeEval(self.datasets, [("custom", "dataset.1")], [self.identity_algorithm],
-                     n_jobs=-2)
+            TimeEval(
+                self.datasets,
+                [("custom", "dataset.1")],
+                [self.identity_algorithm],
+                n_jobs=-2,
+            )
         self.assertIn("n_jobs", str(ex.exception))
         self.assertIn("not supported", str(ex.exception))
 
     def test_missing_experiment_combinations_file(self):
         with self.assertRaises(AssertionError) as ex:
-            TimeEval(self.datasets, [("custom", "dataset.1")], [self.identity_algorithm],
-                     experiment_combinations_file=Path("nonexistent-file.txt"))
+            TimeEval(
+                self.datasets,
+                [("custom", "dataset.1")],
+                [self.identity_algorithm],
+                experiment_combinations_file=Path("nonexistent-file.txt"),
+            )
         self.assertIn("file not found", str(ex.exception))
 
     def test_unknown_dataset(self):
         with self.assertRaises(AssertionError) as ex:
-            TimeEval(self.datasets, [("custom", "dataset.1"), ("does", "not exist")], [self.identity_algorithm])
+            TimeEval(
+                self.datasets,
+                [("custom", "dataset.1"), ("does", "not exist")],
+                [self.identity_algorithm],
+            )
         self.assertIn("could not be found in DatasetManager", str(ex.exception))
 
     def test_nonenforceable_resource_constraints(self):
         with self.assertRaises(AssertionError) as ex:
-            TimeEval(self.datasets, [("custom", "dataset.1")], [self.identity_algorithm],
-                     resource_constraints=ResourceConstraints(task_cpu_limit=1.0))
-        self.assertIn("won't satisfy the specified resource constraints", str(ex.exception))
+            TimeEval(
+                self.datasets,
+                [("custom", "dataset.1")],
+                [self.identity_algorithm],
+                resource_constraints=ResourceConstraints(task_cpu_limit=1.0),
+            )
+        self.assertIn(
+            "won't satisfy the specified resource constraints", str(ex.exception)
+        )
 
     def test_evaluation_continues_after_exception_in_algorithm(self):
         ERROR_MESSAGE = "error message test"
 
         algorithms = [
-            Algorithm(name="exception", main=ErroneousAlgorithm(error_message=ERROR_MESSAGE), data_as_file=False),
-            self.identity_algorithm
+            Algorithm(
+                name="exception",
+                main=ErroneousAlgorithm(error_message=ERROR_MESSAGE),
+                data_as_file=False,
+            ),
+            self.identity_algorithm,
         ]
         with tempfile.TemporaryDirectory() as tmp_path:
-            timeeval = TimeEval(self.datasets, [("custom", "dataset.1")], algorithms, results_path=Path(tmp_path))
+            timeeval = TimeEval(
+                self.datasets,
+                [("custom", "dataset.1")],
+                algorithms,
+                results_path=Path(tmp_path),
+            )
             timeeval.run()
 
         r = timeeval.results
 
         self.assertEqual(r[r.algorithm == "exception"].iloc[0].status, Status.ERROR)
-        self.assertIn(ERROR_MESSAGE, r[r.algorithm == "exception"].iloc[0].error_message)
+        self.assertIn(
+            ERROR_MESSAGE, r[r.algorithm == "exception"].iloc[0].error_message
+        )
 
     def test_no_experiments(self):
         algo = deepcopy(self.identity_algorithm)

--- a/tests/test_timeeval_exceptions.py
+++ b/tests/test_timeeval_exceptions.py
@@ -10,6 +10,7 @@ import pandas as pd
 from tests.fixtures.algorithms import ErroneousAlgorithm
 from timeeval import TimeEval, Algorithm, Datasets, DatasetManager, Status, ResourceConstraints, TrainingType
 from timeeval.adapters import FunctionAdapter
+from timeeval.metrics import DefaultMetrics
 
 
 class TestTimeEvalExceptions(unittest.TestCase):
@@ -89,3 +90,19 @@ class TestTimeEvalExceptions(unittest.TestCase):
         with self.assertRaises(AssertionError) as ex:
             TimeEval(self.datasets, [("test", "dataset-int")], [algo])
         self.assertRegex(str(ex.exception), "[Nn]o [Vv]alid [Ee]xperiments")
+
+    def test_no_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp_path:
+            timeeval = TimeEval(
+                self.datasets,
+                [("test", "dataset-int")],
+                [self.identity_algorithm],
+                results_path=Path(tmp_path),
+                metrics=[],
+            )
+            timeeval.run()
+
+        c = timeeval.results.columns
+        default_metric_names = [m.name for m in DefaultMetrics.default_list()]
+        for metric in default_metric_names:
+            self.assertNotIn(metric, c)

--- a/timeeval/_core/experiments.py
+++ b/timeeval/_core/experiments.py
@@ -185,7 +185,7 @@ class Experiments:
                  base_result_path: Path,
                  resource_constraints: ResourceConstraints = ResourceConstraints.default_constraints(),
                  repetitions: int = 1,
-                 metrics: Optional[List[Metric]] = None,
+                 metrics: List[Metric] = [],
                  skip_invalid_combinations: bool = False,
                  force_training_type_match: bool = False,
                  force_dimensionality_match: bool = False,
@@ -196,7 +196,7 @@ class Experiments:
         self.repetitions = repetitions
         self.base_result_path = base_result_path
         self.resource_constraints = resource_constraints
-        self.metrics = metrics or DefaultMetrics.default_list()
+        self.metrics = metrics
         self.skip_invalid_combinations = skip_invalid_combinations or force_training_type_match or force_dimensionality_match
         self.force_training_type_match = force_training_type_match
         self.force_dimensionality_match = force_dimensionality_match

--- a/timeeval/_core/experiments.py
+++ b/timeeval/_core/experiments.py
@@ -1,24 +1,24 @@
 from contextlib import redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple, List, Optional, Iterator, Any, Dict
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
 
-from .times import Times
 from ..algorithm import Algorithm
-from ..constants import EXECUTION_LOG, ANOMALY_SCORES_TS, METRICS_CSV, HYPER_PARAMETERS
-from ..data_types import AlgorithmParameter, TrainingType, InputDimensionality
-from ..datasets import Datasets, Dataset
+from ..constants import ANOMALY_SCORES_TS, EXECUTION_LOG, HYPER_PARAMETERS, METRICS_CSV
+from ..data_types import AlgorithmParameter, InputDimensionality, TrainingType
+from ..datasets import Dataset, Datasets
 from ..heuristics import inject_heuristic_values
-from ..metrics import Metric, DefaultMetrics
+from ..metrics import Metric
 from ..params import Params
 from ..resource_constraints import ResourceConstraints
 from ..utils.datasets import extract_features, load_dataset, load_labels_only
 from ..utils.encode_params import dump_params, dumps_params
 from ..utils.results_path import generate_experiment_path
+from .times import Times
 
 
 @dataclass
@@ -36,7 +36,10 @@ class Experiment:
 
     @property
     def name(self) -> str:
-        return f"{self.algorithm.name}-{self.dataset.collection_name}-{self.dataset.name}-{self.params_id}-{self.repetition}"
+        return (
+            f"{self.algorithm.name}-{self.dataset.collection_name}-"
+            f"{self.dataset.name}-{self.params_id}-{self.repetition}"
+        )
 
     @property
     def dataset_collection(self) -> str:
@@ -48,19 +51,27 @@ class Experiment:
 
     @property
     def results_path(self) -> Path:
-        return generate_experiment_path(self.base_results_dir, self.algorithm.name, self.params_id,
-                                        self.dataset_collection, self.dataset_name, self.repetition)
+        return generate_experiment_path(
+            self.base_results_dir,
+            self.algorithm.name,
+            self.params_id,
+            self.dataset_collection,
+            self.dataset_name,
+            self.repetition,
+        )
 
     def build_args(self) -> Dict[str, Any]:
         return {
             "results_path": self.results_path,
             "resource_constraints": self.resource_constraints,
             "hyper_params": self.params.to_dict(),
-            "dataset_details": self.dataset
+            "dataset_details": self.dataset,
         }
 
     @staticmethod
-    def scale_scores(y_true: np.ndarray, y_scores: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def scale_scores(
+        y_true: np.ndarray, y_scores: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
         y_true = np.asarray(y_true, dtype=np.int_)
         y_scores = np.asarray(y_scores, dtype=np.float_)
 
@@ -82,12 +93,17 @@ class Experiment:
         # materialize and persist hyper parameters to disk
         self.params = self.params.materialize()
         dump_params(self.params, self.results_path / HYPER_PARAMETERS)
-        hyper_params = dumps_params(self.params)  # must be loaded before assess() or fail() will be called!
+        hyper_params = dumps_params(
+            self.params
+        )  # must be loaded before assess() or fail() will be called!
 
         try:
             with (self.results_path / EXECUTION_LOG).open("a") as logs_file:
-                print(f"Starting evaluation of experiment {self.name}\n=============================================\n",
-                      file=logs_file)
+                print(
+                    f"Starting evaluation of experiment {self.name}\n"
+                    "=============================================\n",
+                    file=logs_file,
+                )
 
             # perform training if necessary
             result = self._perform_training()
@@ -104,8 +120,11 @@ class Experiment:
             y_scores.tofile(str(self.results_path / ANOMALY_SCORES_TS), sep="\n")
 
             with (self.results_path / EXECUTION_LOG).open("a") as logs_file:
-                print(f"Scoring algorithm {self.algorithm.name} with {','.join([m.name for m in self.metrics])} metrics",
-                      file=logs_file)
+                print(
+                    f"Scoring algorithm {self.algorithm.name} with "
+                    f"{','.join([m.name for m in self.metrics])} metrics",
+                    file=logs_file,
+                )
 
                 # calculate quality metrics
                 errors = 0
@@ -118,7 +137,10 @@ class Experiment:
                         print(f"  = {score}", file=logs_file)
                         logs_file.flush()
                     except Exception as e:
-                        print(f"Exception while computing metric {metric}: {e}", file=logs_file)
+                        print(
+                            f"Exception while computing metric {metric}: {e}",
+                            file=logs_file,
+                        )
                         errors += 1
                         if str(e):
                             last_exception = e
@@ -148,15 +170,22 @@ class Experiment:
             return {}
 
         if not self.resolved_train_dataset_path:
-            raise ValueError(f"No training dataset was provided. Algorithm cannot be trained!")
+            raise ValueError(
+                f"No training dataset was provided. Algorithm cannot be trained!"
+            )
 
         if self.algorithm.data_as_file:
             X: AlgorithmParameter = self.resolved_train_dataset_path
         else:
             X = load_dataset(self.resolved_train_dataset_path).values
 
-        with (self.results_path / EXECUTION_LOG).open("a") as logs_file, redirect_stdout(logs_file):
-            print(f"Performing training for {self.algorithm.training_type.name} algorithm {self.algorithm.name}")
+        with (self.results_path / EXECUTION_LOG).open(
+            "a"
+        ) as logs_file, redirect_stdout(logs_file):
+            print(
+                f"Performing training for {self.algorithm.training_type.name} "
+                f"algorithm {self.algorithm.name}"
+            )
             times = Times.from_train_algorithm(self.algorithm, X, self.build_args())
         return times.to_dict()
 
@@ -169,27 +198,38 @@ class Experiment:
                 X = extract_features(dataset)
             else:
                 raise ValueError(
-                    f"Dataset '{self.resolved_test_dataset_path.name}' has a shape that was not expected: {dataset.shape}")
+                    f"Dataset '{self.resolved_test_dataset_path.name}' has a shape "
+                    f"that was not expected: {dataset.shape}"
+                )
 
-        with (self.results_path / EXECUTION_LOG).open("a") as logs_file, redirect_stdout(logs_file):
-            print(f"Performing execution for {self.algorithm.training_type.name} algorithm {self.algorithm.name}")
-            y_scores, times = Times.from_execute_algorithm(self.algorithm, X, self.build_args())
+        with (self.results_path / EXECUTION_LOG).open(
+            "a"
+        ) as logs_file, redirect_stdout(logs_file):
+            print(
+                f"Performing execution for {self.algorithm.training_type.name} "
+                f"algorithm {self.algorithm.name}"
+            )
+            y_scores, times = Times.from_execute_algorithm(
+                self.algorithm, X, self.build_args()
+            )
         return y_scores, times.to_dict()
 
 
 class Experiments:
-    def __init__(self,
-                 dmgr: Datasets,
-                 datasets: List[Dataset],
-                 algorithms: List[Algorithm],
-                 base_result_path: Path,
-                 resource_constraints: ResourceConstraints = ResourceConstraints.default_constraints(),
-                 repetitions: int = 1,
-                 metrics: List[Metric] = [],
-                 skip_invalid_combinations: bool = False,
-                 force_training_type_match: bool = False,
-                 force_dimensionality_match: bool = False,
-                 experiment_combinations_file: Optional[Path] = None):
+    def __init__(
+        self,
+        dmgr: Datasets,
+        datasets: List[Dataset],
+        algorithms: List[Algorithm],
+        base_result_path: Path,
+        resource_constraints: ResourceConstraints = ResourceConstraints.default_constraints(),
+        repetitions: int = 1,
+        metrics: List[Metric] = [],
+        skip_invalid_combinations: bool = False,
+        force_training_type_match: bool = False,
+        force_dimensionality_match: bool = False,
+        experiment_combinations_file: Optional[Path] = None,
+    ):
         self.dmgr = dmgr
         self.datasets = datasets
         self.algorithms = algorithms
@@ -197,38 +237,59 @@ class Experiments:
         self.base_result_path = base_result_path
         self.resource_constraints = resource_constraints
         self.metrics = metrics
-        self.skip_invalid_combinations = skip_invalid_combinations or force_training_type_match or force_dimensionality_match
+        self.skip_invalid_combinations = (
+            skip_invalid_combinations
+            or force_training_type_match
+            or force_dimensionality_match
+        )
         self.force_training_type_match = force_training_type_match
         self.force_dimensionality_match = force_dimensionality_match
-        self.experiment_combinations: Optional[pd.DataFrame] = pd.read_csv(experiment_combinations_file) if experiment_combinations_file else None
+        self.experiment_combinations: Optional[pd.DataFrame] = (
+            pd.read_csv(experiment_combinations_file)
+            if experiment_combinations_file
+            else None
+        )
         if self.skip_invalid_combinations or self.experiment_combinations is not None:
             self._N: Optional[int] = None
         else:
-            self._N = sum(
-                [len(algo.param_config) for algo in self.algorithms]
-            ) * len(self.datasets) * self.repetitions
+            self._N = (
+                sum([len(algo.param_config) for algo in self.algorithms])
+                * len(self.datasets)
+                * self.repetitions
+            )
         self._experiments: Optional[List[Experiment]] = None
 
-    def _should_be_run(self, algorithm: Algorithm, dataset: Dataset, params_id: str) -> bool:
-        return self.experiment_combinations is None or \
-                not self.experiment_combinations[
-                    (self.experiment_combinations.algorithm == algorithm.name) &
-                    (self.experiment_combinations.collection == dataset.datasetId[0]) &
-                    (self.experiment_combinations.dataset == dataset.datasetId[1]) &
-                    (self.experiment_combinations.hyper_params_id == params_id)
-                ].empty
+    def _should_be_run(
+        self, algorithm: Algorithm, dataset: Dataset, params_id: str
+    ) -> bool:
+        return (
+            self.experiment_combinations is None
+            or not self.experiment_combinations[
+                (self.experiment_combinations.algorithm == algorithm.name)
+                & (self.experiment_combinations.collection == dataset.datasetId[0])
+                & (self.experiment_combinations.dataset == dataset.datasetId[1])
+                & (self.experiment_combinations.hyper_params_id == params_id)
+            ].empty
+        )
 
     def materialize_experiments(self) -> Iterator[Experiment]:
         for algorithm in self.algorithms:
             for dataset in self.datasets:
                 if self._check_compatible(dataset, algorithm):
-                    for algorithm_config in algorithm.param_config.iter(algorithm, dataset):
-                        test_path, train_path = self._resolve_dataset_paths(dataset, algorithm)
+                    for algorithm_config in algorithm.param_config.iter(
+                        algorithm, dataset
+                    ):
+                        test_path, train_path = self._resolve_dataset_paths(
+                            dataset, algorithm
+                        )
                         # create parameter hash before executing heuristics
-                        # (they replace the parameter values, but we want to be able to group by original configuration)
+                        # (they replace the parameter values, but we want to be able to
+                        # group by original configuration)
                         params_id = algorithm_config.uid()
                         if self._should_be_run(algorithm, dataset, params_id):
-                            params = inject_heuristic_values(algorithm_config, algorithm, dataset, test_path)
+                            params = inject_heuristic_values(
+                                algorithm_config, algorithm, dataset, test_path
+                            )
                             for repetition in range(1, self.repetitions + 1):
                                 yield Experiment(
                                     algorithm=algorithm,
@@ -240,7 +301,7 @@ class Experiments:
                                     resource_constraints=self.resource_constraints,
                                     metrics=self.metrics,
                                     resolved_test_dataset_path=test_path,
-                                    resolved_train_dataset_path=train_path
+                                    resolved_train_dataset_path=train_path,
                                 )
 
     def __iter__(self) -> Iterator[Experiment]:
@@ -256,12 +317,16 @@ class Experiments:
             self._N = len(self._experiments)
         return self._N
 
-    def _resolve_dataset_paths(self, dataset: Dataset, algorithm: Algorithm) -> Tuple[Path, Optional[Path]]:
+    def _resolve_dataset_paths(
+        self, dataset: Dataset, algorithm: Algorithm
+    ) -> Tuple[Path, Optional[Path]]:
         test_dataset_path = self.dmgr.get_dataset_path(dataset.datasetId, train=False)
         train_dataset_path: Optional[Path] = None
         if algorithm.training_type != TrainingType.UNSUPERVISED:
             try:
-                train_dataset_path = self.dmgr.get_dataset_path(dataset.datasetId, train=True)
+                train_dataset_path = self.dmgr.get_dataset_path(
+                    dataset.datasetId, train=True
+                )
             except KeyError:
                 pass
         return test_dataset_path, train_dataset_path
@@ -270,14 +335,18 @@ class Experiments:
         if not self.skip_invalid_combinations:
             return True
 
-        if (self.force_training_type_match or
-                algorithm.training_type in [TrainingType.SUPERVISED, TrainingType.SEMI_SUPERVISED]):
+        if self.force_training_type_match or algorithm.training_type in [
+            TrainingType.SUPERVISED,
+            TrainingType.SEMI_SUPERVISED,
+        ]:
             train_compatible = algorithm.training_type == dataset.training_type
         else:
             train_compatible = True
 
         if self.force_dimensionality_match:
-            dim_compatible = algorithm.input_dimensionality == dataset.input_dimensionality
+            dim_compatible = (
+                algorithm.input_dimensionality == dataset.input_dimensionality
+            )
         else:
             """
             m = multivariate, u = univariate
@@ -287,5 +356,8 @@ class Experiments:
               m  |  u   | 1
               m  |  m   | 1
             """
-            dim_compatible = not (algorithm.input_dimensionality == InputDimensionality.UNIVARIATE and dataset.input_dimensionality == InputDimensionality.MULTIVARIATE)
+            dim_compatible = not (
+                algorithm.input_dimensionality == InputDimensionality.UNIVARIATE
+                and dataset.input_dimensionality == InputDimensionality.MULTIVARIATE
+            )
         return dim_compatible and train_compatible

--- a/timeeval/metrics/metric.py
+++ b/timeeval/metrics/metric.py
@@ -87,7 +87,7 @@ class Metric(ABC):
         else:
             penalize_mask = penalize_mask | neginf_mask
         if nan_is_0:
-            y_score[nan_mask] = 0.
+            y_score[nan_mask] = 0
         else:
             penalize_mask = penalize_mask | nan_mask
         y_score[penalize_mask] = (~np.array(y_true[penalize_mask], dtype=bool)).astype(np.int_)

--- a/timeeval/timeeval.py
+++ b/timeeval/timeeval.py
@@ -261,7 +261,10 @@ class TimeEval:
         start_date: str = dt.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
         self.results_path = results_path.resolve() / start_date
         self.disable_progress_bar = disable_progress_bar
-        self.metrics: List[Metric] = metrics or DefaultMetrics.default_list()
+        if metrics is None:
+            self.metrics: List[Metric] = DefaultMetrics.default_list()
+        else:
+            self.metrics = metrics
         self.metric_names = [m.name for m in self.metrics]
         self.results = pd.DataFrame(columns=TimeEval.RESULT_KEYS + self.metric_names)
         self.distributed = distributed


### PR DESCRIPTION
If one is just interested in the anomaly scorings produced by the TimeEval algorithms or just the algorithm runtime, we do not require computing any metrics. Currently, TimeEval does not allow specifying no metrics (it always uses the default metrics if none are provided).

Especially when the datasets have no ground-truth information (just zeros in the `is_anomaly` column), no metrics can be computed anyway.

This PR allows specifying `metrics=[]` to force TimeEval to skip algorithm evaluation and do not compute metric scores.

@wenig Commit 27e19b914e8ec1e446c3a4f0e4b3c2d3217ba53c contains the actual changes.