### PR TITLE
Store raw algorithm scorings in result folder

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -1,21 +1,23 @@
 # TimeEval results
 
 On configuring and executing TimeEval, TimeEval applies the algorithms with their configured hyperparameter values on all the datasets.
-It measures the algorithms' runtimes and checks their effectiveness using evaluation measures (:doc:`metrics <api/timeeval.metrics>`).
-The results are stored in a summary file `results.csv`  and a nested folder structure in a results folder (``./results/<timestamp>`` per default).
+It measures the algorithms' runtimes and checks their effectiveness using evaluation measures ({doc}`metrics <api/timeeval.metrics>`).
+The results are stored in a summary file called `results.csv` and a nested folder structure in the results-folder (`./results/<timestamp>` per default).
 The output directory has the following structure:
 
 ```bash
-results/<time-stamp>/
+results/<timestamp>/
 ├── results.csv
 ├── <algorithm_1>/<hyper_params_id>/
 |   ├── <collection_name>/<dataset_name_1>/<repetition_number>/
+│   |   ├── raw_anomaly_scores.ts
 │   |   ├── anomaly_scores.ts
 │   |   ├── docker-algorithm-scores.csv
 │   |   ├── execution.log
 │   |   ├── hyper_params.json
 │   |   └── metrics.csv
 |   └── <collection_name>/<dataset_name_2>/<repetition_number>/
+│       ├── raw_anomaly_scores.ts
 │       ├── anomaly_scores.ts
 │       ├── docker-algorithm-scores.csv
 │       ├── execution.log
@@ -24,34 +26,36 @@ results/<time-stamp>/
 │       └── metrics.csv
 └── <algorithm_2>/<hyper_params_id>/
     └── <collection_name>/<dataset_name_1>/<repetition_number>/
+        ├── raw_anomaly_scores.ts
         ├── anomaly_scores.ts
         ├── docker-algorithm-scores.csv
         ├── execution.log
         ├── hyper_params.json
         └── metrics.csv
-
 ```
-Description of each file is given below. 
 
-## result.csv
+We provide a description of each file below.
 
-For a given dataset, different algorithms with varying hyperparameters yield distict results. The file `result.csv` provides an overview of evalution and contains following attributes:
+## Summary file (`result.csv`)
+
+For a given dataset, different algorithms with varying hyperparameters yield distinct results.
+The file `result.csv` provides an overview of the evaluation run and contains the following attributes:
 
 | Column Name | Datatype | Description |
 | --- | --- | --- |
-| algorithm| str | name of the algorithm as defined in :class:`~timeeval.Algorithm_name` attribute |
-| collection| str | name of the dataset collection. A collection contains similar datasets. | 
+| algorithm| str | name of the algorithm as defined in {class}`~timeeval.Algorithm_name` attribute |
+| collection| str | name of the dataset collection. A collection contains similar datasets. |
 | dataset| str | name of the dataset |
 | algo_training_type | str | specifies, whether a dataset has a training time series with anomaly labels (supervised), with normal data only (semi-supervised), or no training time series at all (unsupervised)|
 | algo_input_dimensionality | str | specifies if the dataset has multiple channels (multivariate) or not (univariate) |
-| dataset_training_type | str | specifies, whether an algorithm requires training data with anomalies (supervised), without normal data only (semi-supervised), or does not require training data (unsupervised) | 
+| dataset_training_type | str | specifies, whether an algorithm requires training data with anomalies (supervised), without normal data only (semi-supervised), or does not require training data (unsupervised) |
 | dataset_input_dimensionality | str |univariate or multivariate (see above) |
 | train_preprocess_time| float64| runtime of the preprocessing step during training in seconds|
 | train_main_time| float64 | runtime of the training in seconds (does not include pre-processing time)|
 | execute_preprocess_time| float64 | runtime of the preprocessing step during execution in seconds|
 | execute_main_time | float64 | runtime of the execution of the algorithm on the test time series in seconds (does not include pre- or post-processing times)|
 | execute_postprocess_time|  float64 | runtime of the post-processing step during execution|
-| status| str | specifies, whether the algorithm executed successfully (:obj:`~timeeval.Status.OK`), exceeded the time limit (:obj:`~timeeval.Status.TIMEOUT`), exceeded the memory limit (:obj:`~timeeval.Status.OOM`), or failed (:obj:`~timeeval.Status.ERROR`) |
+| status| str | specifies, whether the algorithm executed successfully ({obj}`~timeeval.Status.OK`), exceeded the time limit ({obj}`~timeeval.Status.TIMEOUT`), exceeded the memory limit ({obj}`~timeeval.Status.OOM`), or failed ({obj}`~timeeval.Status.ERROR`) |
 | error_message| str | optional detailed error message|
 | repetition| int | repetition number if a dataset-hyperparameter-dataset combination was executed multiple times|
 | hyper_params| float64 | actual hyperparameter values for this execution|
@@ -59,31 +63,32 @@ For a given dataset, different algorithms with varying hyperparameters yield dis
 | metric_1| float64 | value of the first performance metric|
 | ...   |  ... | ...  |
 
-## Directory - <algorithm_1>/<hyper_params_id>/<collection_name>/<dataset_name_1>/<repetition_number>/
+## Directory (`<algorithm_1>/<hyper_params_id>/<collection_name>/<dataset_name_1>/<repetition_number>/`)
 
-For every modification in hyperparameter of algorithms, TimeEval generates a parent directory named by `<algorithm_1>`, which contains a set of nested directories named by `<hyper_params_id>`. Following the directory tree, the deepest directory contains a set of files associated with respective dataset and algorithm as:
+For every experiment in the configured evaluation run, TimeEval creates a new directory in the result folder.
+It stores all the results and temporary files for this single combination of dataset, algorithm, algorithm hyperparameter values, and repetition number.
+The directories are structured in nested folders named by first the algorithm name, followed by the ID of the hyperparameter settings, the dataset collection name, the dataset name, and finally the repetition number.
+Each experiment directory contains at least the following files:
 
-### docker-algorithm-scores.csv
+- `raw_anomaly_scores.ts`:
+  The raw anomaly scores produced by the algorithm after the post-processing function was executed.
+  The file contains no header and a single floating point value in each row for each time step of the input time series.
+  The value range depends on the algorithm.
+- `anomaly_scores.ts`:
+  Normalized anomaly scores.
+  The value range is from 0 (normal) to 1 (most anomalous).
+- `execution.log`:
+  Unstructured log-file of the experiment execution.
+  Contains debugging information from the Adapter, the algorithm, and the metric calculation.
+  If an algorithm fails, its error message usually appear in this log.
+- `metrics.csv`:
+  This file lists the metric and runtime measurements for the corresponding experiment.
+  The used metrics are defined by the user.
+  Find more information in the API documentation: {doc}`api/timeeval.metrics`
+- `hyper_params.json`:
+  Contains a JSON-object with the hyperparameter values used to execute the algorithm on the dataset.
+  If hyperparameter heuristics were defined, the heuristic' values are already resolved.
 
-This single-column file stores evaluation score for the each datapoint of the time series. 
-
-### anomaly_scores.ts
-
-Normalization of the `docker-algorthim-scores.csv` file yields the `anomaly_scores.ts` where every datapoint of the timeseries get a score between 0 to 1. For an anomaly, the score tends to 1. 
-
-### model.pkl
-
-For semi-supervised and supervised algorithm, a pickel file gets generated which contains a trained model from labelled datapoints.  
-
-### execution.log
-
-This log-report summarizes the execution process. Mainly used for debugging purpose as upon failure, it records the source of errors. It also stores the calculated metric score for the applied algorithm on the dataset.
-
-### metrics.csv
-
-   This file consisting information related to metrics used in the experiment. Find more information about it: `api/timeeval.metrics`
-
-### hyper_params.json
-This file stores the information about hyperparameters associated with the applied algorithm.
-	
-	
+All other files are optional and depend on the used {class}`~timeeval.adapters.BaseAdapter`.
+For example, the {class}`~timeeval.adapters.DockerAdapter` usually produces a temporary file called `docker-algorithm-scores.csv`
+to pass the algorithm result from the Docker container to TimeEval, and (semi-)supervised algorithms store their trained model in `model.pkl`-files.

--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -1,7 +1,7 @@
 # TimeEval results
 
 On configuring and executing TimeEval, TimeEval applies the algorithms with their configured hyperparameter values on all the datasets.
-It measures the algorithms' runtimes and checks their effectiveness using evaluation measures ({doc}`metrics <api/timeeval.metrics>`).
+It measures the algorithms' runtimes and checks their effectiveness using evaluation measures ({doc}`metrics <../api/timeeval.metrics>`).
 The results are stored in a summary file called `results.csv` and a nested folder structure in the results-folder (`./results/<timestamp>` per default).
 The output directory has the following structure:
 
@@ -43,24 +43,24 @@ The file `result.csv` provides an overview of the evaluation run and contains th
 
 | Column Name | Datatype | Description |
 | --- | --- | --- |
-| algorithm| str | name of the algorithm as defined in {class}`~timeeval.Algorithm_name` attribute |
+| algorithm| str | name of the algorithm as defined in {class}`~timeeval.Algorithm`#name attribute |
 | collection| str | name of the dataset collection. A collection contains similar datasets. |
 | dataset| str | name of the dataset |
-| algo_training_type | str | specifies, whether a dataset has a training time series with anomaly labels (supervised), with normal data only (semi-supervised), or no training time series at all (unsupervised)|
+| algo_training_type | str | specifies, whether a dataset has a training time series with anomaly labels (supervised), with normal data only (semi-supervised), or no training time series at all (unsupervised) |
 | algo_input_dimensionality | str | specifies if the dataset has multiple channels (multivariate) or not (univariate) |
 | dataset_training_type | str | specifies, whether an algorithm requires training data with anomalies (supervised), without normal data only (semi-supervised), or does not require training data (unsupervised) |
 | dataset_input_dimensionality | str |univariate or multivariate (see above) |
-| train_preprocess_time| float64| runtime of the preprocessing step during training in seconds|
-| train_main_time| float64 | runtime of the training in seconds (does not include pre-processing time)|
-| execute_preprocess_time| float64 | runtime of the preprocessing step during execution in seconds|
-| execute_main_time | float64 | runtime of the execution of the algorithm on the test time series in seconds (does not include pre- or post-processing times)|
-| execute_postprocess_time|  float64 | runtime of the post-processing step during execution|
+| train_preprocess_time| float | runtime of the preprocessing step during training in seconds |
+| train_main_time| float | runtime of the training in seconds (does not include pre-processing time) |
+| execute_preprocess_time| float | runtime of the preprocessing step during execution in seconds |
+| execute_main_time | float | runtime of the execution of the algorithm on the test time series in seconds (does not include pre- or post-processing times) |
+| execute_postprocess_time|  float | runtime of the post-processing step during execution |
 | status| str | specifies, whether the algorithm executed successfully ({obj}`~timeeval.Status.OK`), exceeded the time limit ({obj}`~timeeval.Status.TIMEOUT`), exceeded the memory limit ({obj}`~timeeval.Status.OOM`), or failed ({obj}`~timeeval.Status.ERROR`) |
-| error_message| str | optional detailed error message|
-| repetition| int | repetition number if a dataset-hyperparameter-dataset combination was executed multiple times|
-| hyper_params| float64 | actual hyperparameter values for this execution|
-| hyper_params_id| float64 | alphanumerical hash of the hyperparameter configuration|
-| metric_1| float64 | value of the first performance metric|
+| error_message| str | optional detailed error message |
+| repetition| int | repetition number if a dataset-hyperparameter-dataset combination was executed multiple times |
+| hyper_params| float | actual hyperparameter values for this execution |
+| hyper_params_id| float | alphanumerical hash of the hyperparameter configuration |
+| metric_1| float | value of the first performance metric |
 | ...   |  ... | ...  |
 
 ## Directory (`<algorithm_1>/<hyper_params_id>/<collection_name>/<dataset_name_1>/<repetition_number>/`)
@@ -84,11 +84,11 @@ Each experiment directory contains at least the following files:
 - `metrics.csv`:
   This file lists the metric and runtime measurements for the corresponding experiment.
   The used metrics are defined by the user.
-  Find more information in the API documentation: {doc}`api/timeeval.metrics`
+  Find more information in the API documentation: {doc}`../api/timeeval.metrics`
 - `hyper_params.json`:
   Contains a JSON-object with the hyperparameter values used to execute the algorithm on the dataset.
   If hyperparameter heuristics were defined, the heuristic' values are already resolved.
 
-All other files are optional and depend on the used {class}`~timeeval.adapters.BaseAdapter`.
-For example, the {class}`~timeeval.adapters.DockerAdapter` usually produces a temporary file called `docker-algorithm-scores.csv`
+All other files are optional and depend on the used algorithm {class}`~timeeval.adapters.base.Adapter`.
+For example, the {class}`~timeeval.adapters.docker.DockerAdapter` usually produces a temporary file called `docker-algorithm-scores.csv`
 to pass the algorithm result from the Docker container to TimeEval, and (semi-)supervised algorithms store their trained model in `model.pkl`-files.

--- a/tests/test_output_data.py
+++ b/tests/test_output_data.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 
 from timeeval import TimeEval, Algorithm, Datasets, DatasetManager, AlgorithmParameter, DefaultMetrics
 from timeeval.adapters import FunctionAdapter
-from timeeval.constants import ANOMALY_SCORES_TS, METRICS_CSV, EXECUTION_LOG, HYPER_PARAMETERS, RESULTS_CSV
+from timeeval.constants import RAW_ANOMALY_SCORES_TS, ANOMALY_SCORES_TS, METRICS_CSV, EXECUTION_LOG, HYPER_PARAMETERS, RESULTS_CSV
 from timeeval.params import FixedParameters
 from timeeval.utils.hash_dict import hash_dict
 
@@ -41,6 +41,7 @@ class TestOutputData(unittest.TestCase):
             timeeval.run()
             parent_path = tmp_path / "2021_01_01_00_00_00" / "deviating_from_mean" / self.hash / "test" / "dataset-int" / "1"
 
+            self.assertTrue((parent_path / RAW_ANOMALY_SCORES_TS).exists())
             self.assertTrue((parent_path / ANOMALY_SCORES_TS).exists())
             self.assertTrue((parent_path / EXECUTION_LOG).exists())
             self.assertTrue((parent_path / METRICS_CSV).exists())

--- a/timeeval/_core/experiments.py
+++ b/timeeval/_core/experiments.py
@@ -9,7 +9,7 @@ from sklearn.preprocessing import MinMaxScaler
 
 from .times import Times
 from ..algorithm import Algorithm
-from ..constants import EXECUTION_LOG, ANOMALY_SCORES_TS, METRICS_CSV, HYPER_PARAMETERS
+from ..constants import EXECUTION_LOG, RAW_ANOMALY_SCORES_TS, ANOMALY_SCORES_TS, METRICS_CSV, HYPER_PARAMETERS
 from ..data_types import AlgorithmParameter, TrainingType, InputDimensionality
 from ..datasets import Datasets, Dataset
 from ..heuristics import inject_heuristic_values
@@ -97,6 +97,8 @@ class Experiment:
             result.update(execution_times)
             # backup results to disk
             pd.DataFrame([result]).to_csv(self.results_path / METRICS_CSV, index=False)
+            # persist raw scores to disk
+            y_scores.tofile(str(self.results_path / RAW_ANOMALY_SCORES_TS), sep="\n")
 
             y_true = load_labels_only(self.resolved_test_dataset_path)
             y_true, y_scores = self.scale_scores(y_true, y_scores)

--- a/timeeval/constants.py
+++ b/timeeval/constants.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 METRICS_CSV = "metrics.csv"
 EXECUTION_LOG = "execution.log"
+RAW_ANOMALY_SCORES_TS = "raw_anomaly_scores.ts"
 ANOMALY_SCORES_TS = "anomaly_scores.ts"
 HYPER_PARAMETERS = "hyper_params.json"
 RESULTS_CSV = "results.csv"


### PR DESCRIPTION
TimeEval automatically unifies the anomaly scorings using min-max-scaling. This is fine for evaluation purposes. However, other down-stream tasks might require the raw algorithms scores or other unification methods.

This PR changes TimeEval to always store the raw algorithm scores (in `results/<hidden>/raw_anomaly_scores.ts`) besides the preprocessed ones.