### PR TITLE
Fix MultivarAdapter tests with docker

### DIFF
--- a/tests/integration/test_optuna_integration.py
+++ b/tests/integration/test_optuna_integration.py
@@ -78,7 +78,7 @@ class TestOptunaModule(unittest.TestCase):
         with self.assertRaises(ValueError):
             OptunaModule(OptunaConfiguration(default_storage=None))
 
-    @patch("timeeval.integration.optuna.module.OptunaModule._check_docker_available")
+    @patch("timeeval.integration.optuna.module._check_docker_available")
     def test_checks_docker(self, mock_check):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
@@ -90,7 +90,7 @@ class TestOptunaModule(unittest.TestCase):
 
     @patch("socket.gethostname")
     @patch("timeeval.integration.optuna.module._start_postgres_container")
-    @patch("timeeval.integration.optuna.module.OptunaModule._check_docker_available")
+    @patch("timeeval.integration.optuna.module._check_docker_available")
     def test_prepare_start_storage_container(self, mock_check, mock_start_postgres, mock_hostname):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
@@ -105,7 +105,7 @@ class TestOptunaModule(unittest.TestCase):
         mock_start_postgres.assert_called_with(password="hairy_bumblebee", port=5432)
 
     @patch("socket.gethostname")
-    @patch("timeeval.integration.optuna.module.OptunaModule._check_docker_available")
+    @patch("timeeval.integration.optuna.module._check_docker_available")
     def test_prepare_not_starting_dashboard(self, mock_check, mock_hostname):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
@@ -126,7 +126,7 @@ class TestOptunaModule(unittest.TestCase):
     @patch("socket.gethostname")
     @patch("timeeval.integration.optuna.module._start_dashboard_container")
     @patch("timeeval.integration.optuna.module._start_postgres_container")
-    @patch("timeeval.integration.optuna.module.OptunaModule._check_docker_available")
+    @patch("timeeval.integration.optuna.module._check_docker_available")
     def test_prepare_start_storage_and_dashboard_container(self, mock_check, mock_start_postgres, mock_start_dashboard, mock_hostname):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
@@ -144,7 +144,7 @@ class TestOptunaModule(unittest.TestCase):
 
     @patch("socket.gethostname")
     @patch("timeeval.integration.optuna.module._start_postgres_container")
-    @patch("timeeval.integration.optuna.module.OptunaModule._check_docker_available")
+    @patch("timeeval.integration.optuna.module._check_docker_available")
     def test_prepare_start_on_scheduler(self, mock_check, mock_start_postgres, mock_hostname):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
@@ -159,7 +159,8 @@ class TestOptunaModule(unittest.TestCase):
         )
 
     @patch("timeeval.integration.optuna.module._stop_containers")
-    def test_finalize_local(self, mock_stop_containers):
+    @patch("timeeval.integration.optuna.module._check_docker_available")
+    def test_finalize_local(self, mock_check, mock_stop_containers):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
         module = OptunaModule(OptunaConfiguration(default_storage="postgresql", dashboard=False))
@@ -176,7 +177,8 @@ class TestOptunaModule(unittest.TestCase):
         mock_stop_containers.assert_called_with(remove=True)
 
     @patch("timeeval.integration.optuna.module._stop_containers")
-    def test_finalize_distributed(self, mock_stop_containers):
+    @patch("timeeval.integration.optuna.module._check_docker_available")
+    def test_finalize_distributed(self, mock_check, mock_stop_containers):
         from timeeval.integration.optuna import OptunaModule, OptunaConfiguration
 
         module = OptunaModule(OptunaConfiguration(default_storage="postgresql", dashboard=False))

--- a/timeeval/integration/optuna/module.py
+++ b/timeeval/integration/optuna/module.py
@@ -86,6 +86,14 @@ def _stop_containers(scheduler: Optional[Scheduler] = None, remove: bool = False
         pass
 
 
+def _check_docker_available(reason: str) -> None:
+    if reason:
+        try:
+            docker.from_env()
+        except DockerException as e:
+            raise ValueError(f"No docker client found, but docker is required to {reason}!") from e
+
+
 class OptunaModule(TimeEvalModule):
     """This module is automatically loaded when at least one algorithm uses
     :class:`timeeval.params.BayesianParameterSearch` as parameter config.
@@ -113,17 +121,9 @@ class OptunaModule(TimeEvalModule):
         elif isinstance(self.config.default_storage, str) and self.config.default_storage == "postgresql":
             and_required = " and " if check_docker else ""
             check_docker += and_required + f"start the Optuna storage {self.config.default_storage}"
-        self._check_docker_available(check_docker)
+        _check_docker_available(check_docker)
 
         self.storage_url: Optional[str] = None
-
-    @staticmethod
-    def _check_docker_available(reason: str) -> None:
-        if reason:
-            try:
-                docker.from_env()
-            except DockerException as e:
-                raise ValueError(f"No docker client found, but docker is required to {reason}!") from e
 
     def prepare(self, timeeval: TimeEval) -> None:
         log.info("Optuna module: preparing ...")


### PR DESCRIPTION
The tests for the `MultivarAdapter` failed in CI for Python 3.11 (cf. https://github.com/TimeEval/TimeEval/actions/runs/9189123959).